### PR TITLE
Apply post process

### DIFF
--- a/Sepiatest/Assets/Scenes/SampleScene.unity
+++ b/Sepiatest/Assets/Scenes/SampleScene.unity
@@ -167,7 +167,7 @@ MonoBehaviour:
   m_RequiresOpaqueTextureOption: 2
   m_CameraType: 0
   m_Cameras: []
-  m_RendererIndex: 0
+  m_RendererIndex: 1
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1

--- a/Sepiatest/Assets/Scenes/SampleScene.unity
+++ b/Sepiatest/Assets/Scenes/SampleScene.unity
@@ -213,7 +213,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 32
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -373,8 +373,8 @@ Canvas:
   m_GameObject: {fileID: 1526091535}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
+  m_RenderMode: 1
+  m_Camera: {fileID: 519420031}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1


### PR DESCRIPTION
カメラに写っているものに対して有効な Post Process なため

Canvas の RenderMode が Camera である必要があります